### PR TITLE
Test Runner Improvements

### DIFF
--- a/src/Cedar.Testing.TestRunner/Program.cs
+++ b/src/Cedar.Testing.TestRunner/Program.cs
@@ -3,6 +3,8 @@
     using System;
     using System.IO;
     using System.Reflection;
+    using System.Security;
+    using System.Security.Permissions;
     using Cedar.Testing.Execution;
     using PowerArgs;
 
@@ -17,7 +19,7 @@
             _appDomain = AppDomain.CreateDomain(options.Assembly, AppDomain.CurrentDomain.Evidence, new AppDomainSetup
             {
                 ApplicationBase = Path.GetDirectoryName(_options.Assembly),
-            });
+            }, new PermissionSet(PermissionState.Unrestricted));
         }
 
         public void Run()

--- a/src/Cedar.Testing.TestRunner/Program.cs
+++ b/src/Cedar.Testing.TestRunner/Program.cs
@@ -1,47 +1,42 @@
 ﻿namespace Cedar.Testing.TestRunner
 {
     using System;
-    using System.IO;
     using System.Reflection;
-    using System.Security;
-    using System.Security.Permissions;
     using Cedar.Testing.Execution;
     using PowerArgs;
 
     public class Program
     {
-        private readonly TestRunnerOptions _options;
         private readonly AppDomain _appDomain;
+        private readonly TestRunnerOptions _options;
 
         public Program(TestRunnerOptions options)
         {
             _options = options;
-            _appDomain = AppDomain.CreateDomain(options.Assembly, AppDomain.CurrentDomain.Evidence, new AppDomainSetup
-            {
-                ApplicationBase = Path.GetDirectoryName(_options.Assembly),
-            }, new PermissionSet(PermissionState.Unrestricted));
+
+            _appDomain = TestAppDomain.Create(options.Assembly);
         }
 
         public void Run()
         {
-            var runner = (IScenarioRunner)_appDomain.CreateInstanceAndUnwrap(
+            var runner = (IScenarioRunner) _appDomain.CreateInstanceAndUnwrap(
                 typeof(IScenarioRunner).Assembly.FullName,
                 typeof(ScenarioRunner).FullName,
                 true,
                 BindingFlags.Default,
                 null,
-                new object[] {_options.Assembly, _options.Teamcity, _options.Output, _options.Formatters},
+                new object[] { _options.Assembly, _options.Teamcity, _options.Output, _options.Formatters },
                 null,
                 null);
 
             runner.Run();
         }
 
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             var options = Args.Parse<TestRunnerOptions>(args);
 
-            if (options.Help || String.IsNullOrEmpty(options.Assembly))
+            if(options.Help || String.IsNullOrEmpty(options.Assembly))
             {
                 Console.WriteLine(ArgUsage.GetUsage<TestRunnerOptions>(options: new ArgUsageOptions
                 {

--- a/src/Cedar.Testing.TestRunner/Program.cs
+++ b/src/Cedar.Testing.TestRunner/Program.cs
@@ -53,6 +53,13 @@
                 return;
             }
 
+            AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            {
+                Console.WriteLine(e.ExceptionObject);
+
+                Environment.Exit(1);
+            };
+
             var program = new Program(options);
             program.Run();
         }

--- a/src/Cedar.Testing.TestRunner/Program.cs
+++ b/src/Cedar.Testing.TestRunner/Program.cs
@@ -14,7 +14,7 @@
         public Program(TestRunnerOptions options)
         {
             _options = options;
-            _appDomain = AppDomain.CreateDomain(options.Assembly, null, new AppDomainSetup
+            _appDomain = AppDomain.CreateDomain(options.Assembly, AppDomain.CurrentDomain.Evidence, new AppDomainSetup
             {
                 ApplicationBase = Path.GetDirectoryName(_options.Assembly),
             });

--- a/src/Cedar.Testing/Cedar.Testing.csproj
+++ b/src/Cedar.Testing/Cedar.Testing.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Execution\FindScenarios.cs" />
     <Compile Include="Execution\IScenarioRunner.cs" />
     <Compile Include="Execution\ScenarioRunner.cs" />
+    <Compile Include="Execution\TestAppDomain.cs" />
     <Compile Include="MessageEqualityComparer.cs" />
     <Compile Include="OwinExtensions.cs" />
     <Compile Include="Printing\Bootstrap\BootstrapPrinter.cs" />

--- a/src/Cedar.Testing/Cedar.Testing.csproj
+++ b/src/Cedar.Testing/Cedar.Testing.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Any.cs" />
     <Compile Include="Authorization.cs" />
     <Compile Include="EnumerableExtensions.cs" />
+    <Compile Include="Execution\CategorizedScenario.cs" />
     <Compile Include="Execution\FindScenarios.cs" />
     <Compile Include="Execution\IScenarioRunner.cs" />
     <Compile Include="Execution\ScenarioRunner.cs" />

--- a/src/Cedar.Testing/Execution/CategorizedScenario.cs
+++ b/src/Cedar.Testing/Execution/CategorizedScenario.cs
@@ -1,0 +1,17 @@
+namespace Cedar.Testing.Execution
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class CategorizedScenario
+    {
+        public readonly Type Category;
+        public readonly Task<ScenarioResult> Run;
+
+        public CategorizedScenario(Type category, Task<ScenarioResult> run)
+        {
+            Category = category;
+            Run = run;
+        }
+    }
+}

--- a/src/Cedar.Testing/Execution/FindScenarios.cs
+++ b/src/Cedar.Testing/Execution/FindScenarios.cs
@@ -9,12 +9,12 @@ namespace Cedar.Testing.Execution
 
     public static class FindScenarios
     {
-        public static ILookup<Type, Task<ScenarioResult>> InAssemblies(params Assembly[] assemblies)
+        public static IEnumerable<CategorizedScenario> InAssemblies(params Assembly[] assemblies)
         {
             return (from assembly in assemblies
                 from type in assembly.GetTypes()
                 from result in InType(type)
-                select new { type, result }).ToLookup(x => x.type, x => x.result);
+                select new CategorizedScenario(type, result));
         }
 
         private static IEnumerable<Task<ScenarioResult>> InType(Type type)

--- a/src/Cedar.Testing/Execution/FindScenarios.cs
+++ b/src/Cedar.Testing/Execution/FindScenarios.cs
@@ -4,65 +4,83 @@ namespace Cedar.Testing.Execution
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static class FindScenarios
     {
-        public static IEnumerable<Func<KeyValuePair<Type, Task<ScenarioResult>>>> InAssemblies(params Assembly[] assemblies)
+        public static ILookup<Type, Task<ScenarioResult>> InAssemblies(params Assembly[] assemblies)
         {
-            return from assembly in assemblies
+            return (from assembly in assemblies
                 from type in assembly.GetTypes()
                 from result in InType(type)
-                select result;
+                select new { type, result }).ToLookup(x => x.type, x => x.result);
         }
 
-        private static IEnumerable<Func<KeyValuePair<Type, Task<ScenarioResult>>>> InType(Type type)
+        private static IEnumerable<Task<ScenarioResult>> InType(Type type)
         {
             var constructor = type.GetConstructor(Type.EmptyTypes);
-            
+
             if(constructor == null)
             {
-                return Enumerable.Empty<Func<KeyValuePair<Type, Task<ScenarioResult>>>>();
+                return Enumerable.Empty<Task<ScenarioResult>>();
             }
 
             var singles = from method in type.GetMethods()
                 where method.ReturnType == typeof(Task<ScenarioResult>)
-                select FromMethodInfo(method, constructor);
+                from task in FromMethodInfo(method, constructor)
+                select task;
 
             var enumerables = from method in type.GetMethods()
                 where typeof(IEnumerable<Task<ScenarioResult>>).IsAssignableFrom(method.ReturnType)
-                from result in FromEnumerableMethodInfo(method, constructor)
-                select result;
+                from task in FromEnumerableMethodInfo(method, constructor)
+                select task;
 
             return singles.Concat(enumerables);
         }
 
-        private static Func<KeyValuePair<Type, Task<ScenarioResult>>> FromMethodInfo(MethodInfo method, ConstructorInfo constructor)
+        private static IEnumerable<Task<ScenarioResult>> FromMethodInfo(
+            MethodInfo method,
+            ConstructorInfo constructor)
         {
             var instance = constructor.Invoke(new object[0]);
 
-            var result = ((Task<ScenarioResult>)method.Invoke(instance, new object[0]));
-
-            return () => new KeyValuePair<Type, Task<ScenarioResult>>(method.DeclaringType,
-                result.ContinueWith(task =>
+            var task = (((Task<ScenarioResult>) method.Invoke(instance, new object[0])))
+                .ContinueWith(t =>
                 {
                     DisposeIfNecessary(instance);
+                    return t.Result;
+                });
 
-                    return task.Result;
-                }));
+            return new[] { task };
         }
 
-        private static IEnumerable<Func<KeyValuePair<Type, Task<ScenarioResult>>>> FromEnumerableMethodInfo(
-            MethodInfo method, ConstructorInfo constructor)
+        private static IEnumerable<Task<ScenarioResult>> FromEnumerableMethodInfo(
+            MethodInfo method,
+            ConstructorInfo constructor)
         {
+            long refCount = 0;
+
             var instance = constructor.Invoke(new object[0]);
 
-            var results = (IEnumerable<Task<ScenarioResult>>)method.Invoke(instance, new object[0]);
+            var tasks = ((IEnumerable<Task<ScenarioResult>>) method.Invoke(instance, new object[0]))
+                .Select(task =>
+                {
+                    Interlocked.Increment(ref refCount);
 
-            return results.Select(result => new Func<KeyValuePair<Type, Task<ScenarioResult>>>(
-                () => new KeyValuePair<Type, Task<ScenarioResult>>(method.DeclaringType, result)));
+                    return task.ContinueWith(t =>
+                    {
+                        if(Interlocked.Decrement(ref refCount) == 0)
+                        {
+                            DisposeIfNecessary(instance);
+                        }
+
+                        return t.Result;
+                    });
+                });
+
+            return tasks;
         }
-
 
         private static void DisposeIfNecessary(object instance)
         {

--- a/src/Cedar.Testing/Execution/ScenarioRunner.cs
+++ b/src/Cedar.Testing/Execution/ScenarioRunner.cs
@@ -51,7 +51,15 @@ namespace Cedar.Testing.Execution
 
         public void Run()
         {
-            RunInternal().Wait();
+            try
+            {
+                RunInternal().Wait();
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
         }
 
         private async Task RunInternal()

--- a/src/Cedar.Testing/Execution/TestAppDomain.cs
+++ b/src/Cedar.Testing/Execution/TestAppDomain.cs
@@ -1,0 +1,25 @@
+﻿namespace Cedar.Testing.Execution
+{
+    using System;
+    using System.IO;
+    using System.Security;
+    using System.Security.Permissions;
+
+    public static class TestAppDomain
+    {
+        public static AppDomain Create(string assemblyPath)
+        {
+            var appDomain = AppDomain.CreateDomain(assemblyPath,
+                AppDomain.CurrentDomain.Evidence,
+                new AppDomainSetup
+                {
+                    ApplicationBase = Path.GetDirectoryName(assemblyPath)
+                },
+                new PermissionSet(PermissionState.Unrestricted));
+
+            appDomain.UnhandledException += (_, e) => { Console.WriteLine(e.ExceptionObject); };
+
+            return appDomain;
+        }
+    }
+}

--- a/src/Cedar.Tests/Testing/ScenarioRunnerAcceptanceTests.cs
+++ b/src/Cedar.Tests/Testing/ScenarioRunnerAcceptanceTests.cs
@@ -27,7 +27,7 @@
         {
             var results = await new ScenarioRunner(typeof(EnumerableTests).Assembly, false, "what", "plain").RunTests();
 
-            results.Count().Should().Be(5);
+            results.SelectMany(x => x).Count().Should().Be(5);
         }
     }
 }


### PR DESCRIPTION
The test runner code was extremely ugly and possibly had race conditions on disposal.

Also, if an exception occurred it would cross appdomain boundaries. Since the parent appdomain's binpath is not the same as the assembly under test, this would hide the original exception.

This PR should mitigate that.