### PR TITLE
Polling Mechanism for Middleware Testing

### DIFF
--- a/src/Cedar.Testing/Cedar.Testing.csproj
+++ b/src/Cedar.Testing/Cedar.Testing.csproj
@@ -41,9 +41,9 @@
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="OwinHttpMessageHandler">
-      <HintPath>..\packages\OwinHttpMessageHandler.1.1.0\lib\net45\OwinHttpMessageHandler.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="OwinHttpMessageHandler, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\OwinHttpMessageHandler.1.3.0\lib\net45\OwinHttpMessageHandler.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Cedar.Testing/OwinExtensions.cs
+++ b/src/Cedar.Testing/OwinExtensions.cs
@@ -32,7 +32,8 @@ namespace Cedar.Testing
             var handler = new OwinHttpMessageHandler(appFunc)
             {
                 CookieContainer = new CookieContainer(),
-                UseCookies = true // need this else the auth cookie won't be carried to subsequent requests
+                UseCookies = true, // need this else the auth cookie won't be carried to subsequent requests,
+                AllowAutoRedirect = true
             };
             return new HttpClient(handler, true)
             {

--- a/src/Cedar.Testing/Scenario.Http.cs
+++ b/src/Cedar.Testing/Scenario.Http.cs
@@ -57,6 +57,7 @@
                 var copy = new HttpRequestMessage(original.Method, original.RequestUri);
 
                 original.Headers.ForEach(header => copy.Headers.Add(header.Key, header.Value));
+                original.Properties.ForEach(copy.Properties.Add);
 
                 if(original.Content != null)
                 {

--- a/src/Cedar.Testing/Scenario.Http.cs
+++ b/src/Cedar.Testing/Scenario.Http.cs
@@ -7,6 +7,7 @@
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Reflection;
     using System.Text;
 
     static partial class Scenario
@@ -46,7 +47,24 @@
 
             public static implicit operator HttpRequestMessage(HttpRequest request)
             {
-                return request == null ? null : request._request;
+                var original = request._request;
+
+                if(original == null)
+                {
+                    return null;
+                }
+
+                var copy = new HttpRequestMessage(original.Method, original.RequestUri);
+
+                original.Headers.ForEach(header => copy.Headers.Add(header.Key, header.Value));
+
+                if(original.Content != null)
+                {
+                    copy.Content = new ByteArrayContent(request._body);
+                    original.Content.Headers.ForEach(header => copy.Content.Headers.Add(header.Key, header.Value));
+                }
+
+                return copy;
             }
 
             public static implicit operator HttpRequest(HttpRequestMessage request)

--- a/src/Cedar.Testing/Scenario.Http.cs
+++ b/src/Cedar.Testing/Scenario.Http.cs
@@ -85,7 +85,7 @@
                 var builder = new StringBuilder();
 
                 builder.Append(_request.Method.ToString().ToUpper()).Append(' ')
-                    .Append(_request.RequestUri.PathAndQuery).Append(' ')
+                    .Append(_request.RequestUri).Append(' ')
                     .Append("HTTP/").Append(_request.Version.ToString(2))
                     .AppendLine();
 

--- a/src/Cedar.Testing/Scenario.Middleware.cs
+++ b/src/Cedar.Testing/Scenario.Middleware.cs
@@ -27,13 +27,9 @@
 
         public static class Middleware
         {
-            public interface IWhen : IThen
+            public interface IWhen : IScenario
             {
-                IThen When(Func<HttpResponseMessage, Task<HttpRequestMessage>> when);
-            }
-
-            public interface IThen : IScenario
-            {
+                IWhen When(Func<HttpResponseMessage, Task<HttpRequestMessage>> when);
                 IWhen ThenShould(Expression<Func<HttpResponse, bool>> assertion);
             }
 
@@ -68,7 +64,7 @@
                     _expect = new List<object>();
                 }
 
-                public IThen When(Func<HttpResponseMessage, Task<HttpRequestMessage>> when)
+                public IWhen When(Func<HttpResponseMessage, Task<HttpRequestMessage>> when)
                 {
                     IList<Expression<Func<HttpResponse, bool>>> assertions =
                         new List<Expression<Func<HttpResponse, bool>>>();

--- a/src/Cedar.Testing/ScenarioExtensions.cs
+++ b/src/Cedar.Testing/ScenarioExtensions.cs
@@ -24,28 +24,28 @@
             }
         }
 
-        public static Scenario.Middleware.IThen When(
+        public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
             Func<Task<HttpRequestMessage>> request)
         {
             return scenario.When(_ => request());
         }
 
-        public static Scenario.Middleware.IThen When(
+        public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
             HttpRequestMessage when)
         {
             return scenario.When(_ => when);
         }
 
-        public static Scenario.Middleware.IThen When(
+        public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
             Func<HttpRequestMessage> when)
         {
             return scenario.When(_ => when());
         }
 
-        public static Scenario.Middleware.IThen When(
+        public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario, 
             Func<HttpResponseMessage, HttpRequestMessage> when)
         {

--- a/src/Cedar.Testing/ScenarioExtensions.cs
+++ b/src/Cedar.Testing/ScenarioExtensions.cs
@@ -26,32 +26,40 @@
 
         public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
-            Func<Task<HttpRequestMessage>> request)
+            Func<Task<HttpRequestMessage>> request,
+            Func<HttpResponseMessage, bool> canContinue = null,
+            TimeSpan? timeout = default(TimeSpan?))
         {
-            return scenario.When(_ => request());
+            return scenario.When(_ => request(), canContinue, timeout);
         }
 
         public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
-            HttpRequestMessage when)
+            HttpRequestMessage when,
+            Func<HttpResponseMessage, bool> canContinue = null,
+            TimeSpan? timeout = default(TimeSpan?))
         {
-            return scenario.When(_ => when);
+            return scenario.When(_ => when, canContinue, timeout);
         }
 
         public static Scenario.Middleware.IWhen When(
             this Scenario.Middleware.IWhen scenario,
-            Func<HttpRequestMessage> when)
+            Func<HttpRequestMessage> when,
+            Func<HttpResponseMessage, bool> canContinue = null,
+            TimeSpan? timeout = default(TimeSpan?))
         {
-            return scenario.When(_ => when());
+            return scenario.When(_ => when(), canContinue, timeout);
         }
 
         public static Scenario.Middleware.IWhen When(
-            this Scenario.Middleware.IWhen scenario, 
-            Func<HttpResponseMessage, HttpRequestMessage> when)
+            this Scenario.Middleware.IWhen scenario,
+            Func<HttpResponseMessage, HttpRequestMessage> when,
+            Func<HttpResponseMessage, bool> canContinue = null,
+            TimeSpan? timeout = default(TimeSpan?))
         {
-            return scenario.When(response => Task.FromResult(when(response)));
+            return scenario.When(response => Task.FromResult(when(response)), canContinue, timeout);
         }
-
+        
         public static Scenario.Query.IThen When(
             this Scenario.Query.IWhen scenario,
             HttpRequestMessage when)

--- a/src/Cedar.Testing/packages.config
+++ b/src/Cedar.Testing/packages.config
@@ -3,7 +3,7 @@
 <packages>
   <package id="CompareNETObjects" version="3.01.0.0" targetFramework="net45" />
   <package id="Inflector" version="1.0.0.0" targetFramework="net451" />
-  <package id="OwinHttpMessageHandler" version="1.1.0" targetFramework="net45" />
+  <package id="OwinHttpMessageHandler" version="1.3.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
Comments inline.

```csharp
await Scenario.ForMiddleware(myMidFunc)
    .When(() => new HttpRequestMessage(HttpMethod.Put, "/some-resource")
    {
        Content = new StringContent("stuff")
    })
    .ThenShould(response => response.StatusCode == HttpStatusCode.Accepted) // 202
    .When(
    	// you can use the previous response for the next request if you want
    	response => new HttpRequestMessage(HttpMethod.Get, "/some-resource"), 
    	// keep resending the request until a response code of 200 comes back
    	response => response.StatusCode == HttpStatusCode.OK,
		// for up to five seconds. An exception will be thrown if the timeout is reached.
    	TimeSpan.FromSeconds(5))
    .ThenShould(response => response.StatusCode == HttpStatusCode.OK && Encoding.UTF8.GetString(response.Body()).Equals("stuff"));
```